### PR TITLE
Fix halt function

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -87,12 +87,13 @@ pub extern fn kmain() -> ! {
         println!("kbd: enable unsuccessful");
     }
 
-    halt()
+    unsafe { halt() }
 }
 
-// TODO move somewhere else
-fn halt() -> ! {
+unsafe fn halt() -> ! {
+    asm!("cli");
+
     loop {
-        unsafe { asm!("hlt") }
+        asm!("hlt")
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -92,6 +92,7 @@ pub extern fn kmain() -> ! {
 
 // TODO move somewhere else
 fn halt() -> ! {
-    unsafe { asm!("hlt") }
-    loop {} // Required to trick rust
+    loop {
+        unsafe { asm!("hlt") }
+    }
 }


### PR DESCRIPTION
Since the `hlt` instruction does in fact return when an interupt is fired, we should put it *inside* the loop. Alternatively, we could first disable interrupts and then hlt.